### PR TITLE
🔧 Add command to create a html coverage report

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -33,6 +33,7 @@ deps =
     coverage
 commands =
     coverage run -m pytest --basetemp={envtmpdir} {posargs}
+    coverage html --omit .tox/*,unittests/*
     coverage report --fail-under 80 --omit .tox/*,unittests/*
 
 [testenv:dev]


### PR DESCRIPTION
I added a command to create a **html** coverage report.
If you run the coverage environment it will create a `htmlcov` directory. There you will find a `index.html` file with a nice overview of all checked files. Then you can click on a file name and see which parts of our code is not covered by the tests yet. 
If you just would like to recreate the report you can run

```bash
coverage html --omit .tox/*,unittests/*
``` 

To run this command, _coverage_ has to be installed in you _dev_ environment
```bash
pip install coverage
``` 
## Some impressions
![image](https://user-images.githubusercontent.com/68426071/114882094-e50f2e80-9e03-11eb-909c-7dcbcd39d704.png)
![image](https://user-images.githubusercontent.com/68426071/114882160-f5bfa480-9e03-11eb-9f2c-8042c7f9492f.png)
