### PR TITLE
🔧 Add black profile to isort to avoid conflicts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,7 @@ line-length = 120
 
 [tool.isort]
 line_length = 120
+profile = "black"
 
 [tool.pylint."MESSAGES CONTROL"]
 max-line-length = 120


### PR DESCRIPTION
Avoid conflicts between isort and black during the pre-commit checks.
Source: https://github.com/PyCQA/isort/issues/1518#issuecomment-703056188
At the top of the github thread, you can also see the problem.