### PR TITLE
🔧 gitignore auto-generated requirements.txt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ share/python-wheels/
 *.egg-info/
 .installed.cfg
 *.egg
+requirements.txt
 MANIFEST
 
 # PyInstaller


### PR DESCRIPTION
`requirements.txt` will auto-generate on every packaging run (i.e., everytime that tox -e dev is run). `requirements.in` contains all necessary information.