### PR TITLE
🐛🏗 Fix release workflow / Remove leftover `setup.py` artefacts

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -8,7 +8,6 @@
 
 # on:
 #   release:
-#     branches: main
 #     types: [created, edited]
 
 # jobs:
@@ -46,10 +45,10 @@
 #       - name: Install dependencies
 #         run: |
 #           python -m pip install --upgrade pip
-#           pip install setuptools setuptools-scm wheel twine
+#           pip install -r dev_requirements/requirements-packaging.txt
 #       - name: Build a binary wheel and a source tarball
 #         run: |
-#           python setup.py sdist bdist_wheel
+#           python -m build
 #       - name: Publish distribution 📦 to PyPI
 #         if: startsWith(github.ref, 'refs/tags/v')
 #         uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
since we introduced hatch, there is no setup.py anymore.
also we do want to allow releases from non-main branches
