### PR TITLE
fix: install test requirements in type_check env

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -34,7 +34,7 @@ commands =
 # the type_check environment checks the type hints using mypy
 setenv = PYTHONPATH = {toxinidir}/src
 deps =
-    -r requirements.txt
+    {[testenv:tests]deps}
     -r dev_requirements/requirements-type_check.txt
 commands =
     mypy --show-error-codes src/mypackage


### PR DESCRIPTION
we're type checking the tests, which is good.
but if you install test requirements then mypy complain that those are unknown (import-error). by "inheriting" the deps from the tests, mypy can check those, too