### PR TITLE
fix: spell_check entire `src`

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -48,7 +48,7 @@ deps =
     -r requirements.txt
     -r dev_requirements/requirements-spell_check.txt
 commands =
-    codespell --ignore-words=domain-specific-terms.txt src/ibims
+    codespell --ignore-words=domain-specific-terms.txt src
     codespell --ignore-words=domain-specific-terms.txt README.md
     # add single files (ending with .py) or packages here
 


### PR DESCRIPTION
not only a specific package name