### PR TITLE
feat: Add explicit black target versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ Homepage = "https://github.com/Hochfrequenz/python_template_repository"
 
 [tool.black]
 line-length = 120
+target_version = ["py311", "py312"]
 
 [tool.isort]
 line_length = 120


### PR DESCRIPTION
this is useful if black (running e.g. in 3.12) would introduce formatting changes that break older python versions => prevents SyntaxErrors
