### PR TITLE
Remove `pip-compile` step from dev env setup

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -83,7 +83,6 @@ deps =
     pre-commit
 commands =
     python -m pip install --upgrade pip
-    pip-compile pyproject.toml
     pip install -r requirements.txt
     pre-commit install
 


### PR DESCRIPTION
because this leads to upgrade that might not be inteded https://teams.microsoft.com/l/message/19:3ea284d17f5b479ebb10bc3e30dd8a1e@thread.tacv2/1715333891909?tenantId=fb2b0361-fa12-48a5-bade-533bf89760d9&groupId=8315a0ee-4353-4a0b-89f5-1948413a5422&parentMessageId=1714912065838&teamName=%F0%9F%90%8DZen-of-Python-Masters%F0%9F%90%8D&channelName=General&createdTime=1715333891909