### PR TITLE
Use `skip_install=true` for tox.ini dev environment

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -23,7 +23,7 @@ commands = python -m pytest --basetemp={envtmpdir} {posargs}
 deps =
     {[testenv:tests]deps}
 extras = linting
-    # add your fixtures like e.g. pytest_datafiles here
+allowlist_externals = pylint
 setenv = PYTHONPATH = {toxinidir}/src
 commands =
     pylint mypackage
@@ -36,6 +36,7 @@ setenv = PYTHONPATH = {toxinidir}/src
 deps =
     {[testenv:tests]deps}
 extras = type_check
+allowlist_externals = mypy
 commands =
     mypy --show-error-codes src/mypackage --strict
     mypy --show-error-codes unittests --strict
@@ -47,6 +48,7 @@ setenv = PYTHONPATH = {toxinidir}/src
 deps =
     -r requirements.txt
 extras = spell_check
+allowlist_externals = codespell
 commands =
     codespell --ignore-words=domain-specific-terms.txt src
     codespell --ignore-words=domain-specific-terms.txt README.md
@@ -58,6 +60,7 @@ changedir = unittests
 deps =
     {[testenv:tests]deps}
 extras = coverage
+allowlist_externals = coverage
 setenv = PYTHONPATH = {toxinidir}/src
 commands =
     coverage run -m pytest --basetemp={envtmpdir} {posargs}


### PR DESCRIPTION
so that the package itself is not installed into the site packages which is rather annoying to debug
